### PR TITLE
Use browser back navigation

### DIFF
--- a/src/article.js
+++ b/src/article.js
@@ -149,7 +149,7 @@ const Article = ({ children, meta, references, displayTitle }) => {
             <Button
               inverted
               size='xs'
-              href='/research'
+              onClick={() => window.history.back()}
               prefix={<Left />}
               sx={{
                 ml: ['-2px', '-2px', '-2px', '-2px'],

--- a/src/post.js
+++ b/src/post.js
@@ -82,7 +82,7 @@ const Post = ({ children, meta, number }) => {
           <Button
             inverted
             size='xs'
-            href='/blog'
+            onClick={() => window.history.back()}
             prefix={<Left />}
             sx={{
               ml: ['-2px', '-2px', '-2px', '-2px'],

--- a/src/supplement.js
+++ b/src/supplement.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { Box, Divider } from 'theme-ui'
 import { Layout, Row, Column, Button, formatDate } from '@carbonplan/components'
 import { Left } from '@carbonplan/icons'
-import QuickLook from './quick-look'
 import ReadMore from './read-more'
 
 const prefix = 'https://images.carbonplan.org'
@@ -26,7 +25,7 @@ const Supplement = ({ children, meta }) => {
           sx={{ mb: [-2, -4, 0, 0], mt: [3, 4, '109px', '154px'] }}
         >
           <Button
-            href={meta.back}
+            onClick={() => window.history.back()}
             inverted
             size='xs'
             prefix={<Left />}

--- a/src/tool.js
+++ b/src/tool.js
@@ -34,7 +34,7 @@ const Tool = ({
             sx={{ mb: [-2, -4, 0, 0], mt: [3, 4, '109px', '154px'] }}
           >
             <Button
-              href={'/research'}
+              onClick={() => window.history.back()}
               inverted
               size='xs'
               prefix={<Left />}


### PR DESCRIPTION
Instead of hardcoding back links, rely on `window.history.back()` to step backwards in browser history (same behavior as using browser back button). This allows scroll to be preserved and fixes some existing flows like:

- /research
  - inline link to FAQ ->
- /research/forest-offsets-explainer-faq
  - hardcoded `meta.back` link ->
- /research/forest-offsets-explainer
