### PR TITLE
Apply default styles to links rendered with in Sidenote

### DIFF
--- a/src/sidenote.js
+++ b/src/sidenote.js
@@ -6,7 +6,15 @@ const Sidenote = ({ children, url, ...props }) => {
   const { number, color } = useSidenote(children, url)
 
   return (
-    <InlineNote number={number} color={color} url={url} {...props}>
+    <InlineNote
+      number={number}
+      color={color}
+      url={url}
+      sxReference={{
+        '& a': { color: 'inherit', '&:hover': { color: 'inherit' } },
+      }}
+      {...props}
+    >
       {children}
     </InlineNote>
   )


### PR DESCRIPTION
Add default styling to `a` tags rendered within `Sidenote` to accommodate usage like:
```jsx
<Sidenote>This is a sidenote with [a link](https://example.com) that is styled within it.</Sidenote>
```

before:
<img width="329" alt="Screen Shot 2022-05-03 at 11 24 33 AM" src="https://user-images.githubusercontent.com/12436887/166520726-ab706dca-a8cb-4129-a4b9-04949ea94782.png">


after:
<img width="333" alt="Screen Shot 2022-05-03 at 11 24 12 AM" src="https://user-images.githubusercontent.com/12436887/166520572-c3043884-199b-4700-a7cc-45b2475775b9.png">

