### PR TITLE
Update Post to support custom author image sources

### DIFF
--- a/src/post.js
+++ b/src/post.js
@@ -36,9 +36,9 @@ const Authors = ({ authors }) => {
           fontSize: [2, 2, 2, 3],
         }}
       >
-        {authors.map((author, ix) => (
+        {authors.map(({ id }, ix) => (
           <Text
-            key={author}
+            key={id}
             sx={{
               display: 'inline-block',
               mr: [2],
@@ -47,7 +47,7 @@ const Authors = ({ authors }) => {
               fontSize: [2, 2, 2, 3],
             }}
           >
-            {author.replace(/ /g, '\u00a0')}
+            {id.replace(/ /g, '\u00a0')}
             {'\u00a0'}
             {ix < authors.length - 1 ? '+' : ''}
           </Text>
@@ -60,7 +60,13 @@ const Authors = ({ authors }) => {
 const Post = ({ back = '/blog', children, meta, number, ...props }) => {
   const colors = ['red', 'orange', 'yellow', 'pink']
   const avatars = meta.authors.map((d, i) => {
-    return { name: d, color: colors[(number + i) % 4] }
+    const color = colors[(number + i) % 4]
+    if (typeof d === 'string') {
+      return { id: d, name: d, color }
+    } else {
+      const { src, name } = d
+      return { id: name, src, color }
+    }
   })
 
   return (
@@ -146,7 +152,7 @@ const Post = ({ back = '/blog', children, meta, number, ...props }) => {
               }}
             >
               <Column start={[1]} width={[3, 3, 2, 2]} sx={{ mb: [3] }}>
-                <Authors authors={meta.authors} />
+                <Authors authors={avatars} />
               </Column>
               <Column
                 start={[4, 4, 1, 1]}


### PR DESCRIPTION
Update the `Post` component to accept `meta.authors` to accept an array where each entry is _either_ a string that can safely be passed to `Avatar` as `name` or an object containing `name` and `src`, where only the latter is passed to `Avatar`. This allows us more flexibility with our authors lists.

For example,
```yaml
---
authors:
  - Kata Martin
  - name: Author Two
    src: https://media-exp1.licdn.com/dms/image/C560BAQGCdpmY4twIUQ/company-logo_200_200/0/1591487268034?e=2147483647&v=beta&t=bqC5r7UW9VDijSzyUPquteq0s0Xff3Uoatrgvk5hscU
---
```
will result in:

<img width="202" alt="Screen Shot 2022-05-19 at 12 03 47 PM" src="https://user-images.githubusercontent.com/12436887/169382172-12753817-fe08-4362-869e-860ec6f4778f.png">
