### PR TITLE
Sidebar updates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,12 @@
 export { default as Article } from './article'
 export { default as Cite } from './cite'
 export { default as Commentary } from './commentary'
-export { Sidebar, SidebarAttachment, SidebarFooter } from './sidebar'
+export {
+  Sidebar,
+  SidebarAttachment,
+  SidebarDivider,
+  SidebarFooter,
+} from './sidebar'
 export { default as Endnote } from './endnote'
 export { default as NavSection } from './nav-section'
 export { default as NavMenu } from './nav-menu'

--- a/src/sidebar/index.js
+++ b/src/sidebar/index.js
@@ -1,3 +1,4 @@
 export { default as Sidebar } from './sidebar'
 export { default as SidebarAttachment } from './sidebar-attachment'
 export { default as SidebarFooter } from './sidebar-footer'
+export { default as SidebarDivider } from './sidebar-divider'

--- a/src/sidebar/sidebar.js
+++ b/src/sidebar/sidebar.js
@@ -56,26 +56,28 @@ const Sidebar = ({
 
   return (
     <>
-      <SidebarAttachment
-        width={width}
-        side={side}
-        expanded={expanded}
-        sx={{ bottom: ['18px', '18px', '18px', '16px'] }}
-      >
-        <Button
-          onClick={handleToggleExpanded}
-          prefix={side === 'left' ? icon : null}
-          suffix={side === 'right' ? icon : null}
-          size='sm'
-          sx={{
-            display: ['none', 'none', 'inline-block', 'inline-block'],
-            cursor: 'pointer',
-            color: 'primary',
-          }}
+      {setExpanded && (
+        <SidebarAttachment
+          width={width}
+          side={side}
+          expanded={expanded}
+          sx={{ bottom: ['18px', '18px', '18px', '16px'] }}
         >
-          {expanded ? null : tooltip}
-        </Button>
-      </SidebarAttachment>
+          <Button
+            onClick={handleToggleExpanded}
+            prefix={side === 'left' ? icon : null}
+            suffix={side === 'right' ? icon : null}
+            size='sm'
+            sx={{
+              display: ['none', 'none', 'inline-block', 'inline-block'],
+              cursor: 'pointer',
+              color: 'primary',
+            }}
+          >
+            {expanded ? null : tooltip}
+          </Button>
+        </SidebarAttachment>
+      )}
       <Row>
         <Column width={width} start={1}>
           <Box

--- a/src/sidebar/sidebar.js
+++ b/src/sidebar/sidebar.js
@@ -1,6 +1,6 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 import { Box, Flex } from 'theme-ui'
-import { Button, Row, Column, getScrollbarWidth } from '@carbonplan/components'
+import { Button, Row, Column } from '@carbonplan/components'
 import { ArrowThin } from '@carbonplan/icons'
 
 import SidebarAttachment from './sidebar-attachment'
@@ -15,9 +15,6 @@ const Sidebar = ({
   side = 'left',
   width = 3,
 }) => {
-  const [customScrollbar] = useState(
-    () => document && getScrollbarWidth(document) > 0
-  )
   const handleToggleExpanded = useCallback(() => {
     if (!expanded) {
       setExpanded(true)
@@ -157,7 +154,6 @@ const Sidebar = ({
                     >
                       <Row
                         columns={width}
-                        className={customScrollbar ? 'custom-scrollbar' : null}
                         sx={{
                           flex: '0 0 auto',
                           height: '100%',
@@ -166,9 +162,6 @@ const Sidebar = ({
                           py: [4],
                           px: [4, 5, 5, 6],
                           mx: [-4, -5, -5, -6],
-                          '&::-webkit-scrollbar-corner': customScrollbar
-                            ? { background: 'rgb(0, 0, 0, 0)' }
-                            : {},
                         }}
                       >
                         <Column width={4} start={1}>


### PR DESCRIPTION
- Removes custom sidebar styling logic unnecessary as of https://github.com/carbonplan/components/pull/157
- Avoids rendering toggle in `SidebarAttachment` unless `setExpanded` is provided (allows same Sidebar pattern to be used when Sidebar should always remain open)
- Includes `SidebarDivider` in exports