### PR TITLE
Improve Cite grouping

### DIFF
--- a/src/cite.js
+++ b/src/cite.js
@@ -150,7 +150,7 @@ const Cite = ({ id, ids, ...props }) => {
   }
 
   if (id) {
-    return <CiteInner id={id} {...props} />
+    return <SingleCite id={id} {...props} />
   }
 
   const count = ids.length
@@ -158,7 +158,7 @@ const Cite = ({ id, ids, ...props }) => {
   if (count === 0) {
     throw Error('array of ids is empty')
   } else if (count === 1) {
-    return <CiteInner id={ids[0]} {...props} />
+    return <SingleCite id={ids[0]} {...props} />
   }
 
   let hide
@@ -170,7 +170,6 @@ const Cite = ({ id, ids, ...props }) => {
     hide = new Array(count).fill(props.hide)
   }
 
-  console.log(ids)
   if (count === 2) {
     return (
       <>

--- a/src/references.js
+++ b/src/references.js
@@ -23,6 +23,27 @@ export const useReference = (id, first) => {
     mode,
   }
 }
+export const useReferenceGroup = (ids) => {
+  const { references, color, getNumber, getSide, mode } = useContext(References)
+  const first = ids[0]
+
+  return ids.map((id) => {
+    const reference = references[id]
+    if (!reference) {
+      throw Error(`referencee ${id} not found`)
+    }
+
+    const number = getNumber(id)
+
+    return {
+      reference,
+      number,
+      color,
+      side: getSide(id, first),
+      mode,
+    }
+  })
+}
 
 export const useSidenote = (sidenote, url) => {
   const { color, mode, getSide, registerSidenote } = useContext(References)


### PR DESCRIPTION
This PR makes improvements to the rendering of non-continuous lists of citations.

### Desktop: before
<img width="116" alt="CleanShot 2024-03-07 at 14 42 04@2x" src="https://github.com/carbonplan/layouts/assets/12436887/665af409-26ac-4a53-aeae-ce5b49b96f47">
<img width="102" alt="CleanShot 2024-03-07 at 14 42 15@2x" src="https://github.com/carbonplan/layouts/assets/12436887/39672f64-e6cf-49b8-9fbd-5086ca2212bf">

<img width="116" alt="CleanShot 2024-03-07 at 14 42 18@2x" src="https://github.com/carbonplan/layouts/assets/12436887/84970446-4dba-4bad-a973-ac6c0e60fac9">

### Desktop: after
<img width="154" alt="CleanShot 2024-03-07 at 14 54 04@2x" src="https://github.com/carbonplan/layouts/assets/12436887/2c4a947a-7c6f-49ab-96a5-a024e03f39fb">

<img width="166" alt="CleanShot 2024-03-07 at 14 54 29@2x" src="https://github.com/carbonplan/layouts/assets/12436887/d4793d2b-7829-43f9-b914-e6c64fd371f4">

<img width="147" alt="CleanShot 2024-03-07 at 14 54 33@2x" src="https://github.com/carbonplan/layouts/assets/12436887/233520a9-e0c7-462a-bf06-c145b135c28d">

### Mobile (unchanged)
<img width="106" alt="CleanShot 2024-03-07 at 14 55 18@2x" src="https://github.com/carbonplan/layouts/assets/12436887/55231e33-715a-46e0-9338-64d764a441a8">
<img width="103" alt="CleanShot 2024-03-07 at 14 55 25@2x" src="https://github.com/carbonplan/layouts/assets/12436887/3af7f4a7-21cd-41f9-8404-f395520e19c7">
<img width="122" alt="CleanShot 2024-03-07 at 14 55 28@2x" src="https://github.com/carbonplan/layouts/assets/12436887/9bacba25-21d8-47a2-8fdc-6a7cc330af15">
